### PR TITLE
PRD-2823 Add support for version command without common params

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ $ cmdk version
 
 ```shell
 # For Linux
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.1/cmdk-cli-client-0.1.1-linux-x86_64.zip \
-    --output cmdk-cli-client-0.1.1-linux-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.1/cmdk-cli-client-0.1.2-linux-x86_64.zip \
+    --output cmdk-cli-client-0.1.2-linux-x86_64.zip
 ```
 
 ```shell
 # For MacOS
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.1/cmdk-cli-client-0.1.1-osx-x86_64.zip \
-    --output cmdk-cli-client-0.1.1-osx-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.1/cmdk-cli-client-0.1.2-osx-x86_64.zip \
+    --output cmdk-cli-client-0.1.2-osx-x86_64.zip
 ```
   
 2. After downloading the ZIP file, extract its contents using the following command (replace <file> with the actual downloaded file name), and install the binary:

--- a/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
+++ b/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
@@ -3,6 +3,7 @@ package dev.commandk.cli // ktlint-disable filename
 import com.github.ajalt.clikt.core.CliktCommand
 import com.github.ajalt.clikt.core.context
 import com.github.ajalt.clikt.core.subcommands
+import com.github.ajalt.clikt.parameters.options.default
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.sources.MapValueSource
@@ -19,6 +20,7 @@ import dev.commandk.cli.common.CommonEnvironmentVars
 import dev.commandk.cli.context.AccessAuthorizationParameters
 import dev.commandk.cli.context.CommonContext
 import dev.commandk.cli.services.ConfigPropertiesLoader
+import io.ktor.http.content.Version
 import kotlinx.cinterop.ExperimentalForeignApi
 import kotlinx.cinterop.toKString
 import platform.posix.getenv
@@ -28,7 +30,7 @@ class CommandK(
 ) : CliktCommand("cmdk", autoCompleteEnvvar = CommonEnvironmentVars.CompletionScript, name = "cmdk") {
     companion object {
         const val ApplicationName = "commandk-cli"
-        const val Version = "0.1.1"
+        const val Version = "0.1.2"
     }
 
     private val loadedConfig: Map<String, String>
@@ -81,13 +83,20 @@ val subcommands = emptyList<CliktCommand>() +
         SecretsCommand()
             .subcommands(ImportCommand(commandKApiProvider), GetCommand(commandKApiProvider)),
         RunCommand(commandKApiProvider),
-        VersionCommand()
+        VersionCommand(Terminal())
     )
 
 @OptIn(ExperimentalForeignApi::class)
-fun main(args: Array<String>) = CommandK(
-    (
-        (getenv("CMDK_CONFIG_FILE")?.toKString())
-            ?: (getenv("HOME")?.let { "${it.toKString()}/.commandk.config.json" })
-        ),
-).subcommands(subcommands).main(args)
+fun main(args: Array<String>) {
+    if (args[0] == "version") {
+        VersionCommand(Terminal())
+            .run()
+    } else {
+        CommandK(
+            (
+                (getenv("CMDK_CONFIG_FILE")?.toKString())
+                    ?: (getenv("HOME")?.let { "${it.toKString()}/.commandk.config.json" })
+                ),
+        ).subcommands(subcommands).main(args)
+    }
+}

--- a/src/nativeMain/kotlin/dev/commandk/cli/commands/VersionCommand.kt
+++ b/src/nativeMain/kotlin/dev/commandk/cli/commands/VersionCommand.kt
@@ -1,20 +1,14 @@
 package dev.commandk.cli.commands
 
-import arrow.core.right
 import com.github.ajalt.clikt.core.CliktCommand
-import com.github.ajalt.clikt.core.requireObject
+import com.github.ajalt.mordant.terminal.Terminal
 import dev.commandk.cli.CommandK
-import dev.commandk.cli.context.CommonContext
-import dev.commandk.cli.context.cc
-import dev.commandk.cli.context.executeCliCommand
 
-class VersionCommand : CliktCommand("Get the current CommandK CLI version") {
-    private val commonContext by requireObject<CommonContext>()
+class VersionCommand(
+    private val terminal: Terminal
+) : CliktCommand("Get the current CommandK CLI version") {
     override fun run() {
-        commonContext.executeCliCommand {
-            cc().writeLine("CommandK / CLI")
-            cc().writeLine("  Version - ${CommandK.Version}")
-            Unit.right()
-        }
+        terminal.println("CommandK / CLI")
+        terminal.println("  Version - ${CommandK.Version}")
     }
 }


### PR DESCRIPTION
### Why is the change needed?
The `version` subcommand when implemented as a regular subcommand, requires all common options to be specified mandatorily. This means that a user cannot simply run `cmdk version` without having an access token defined somewhere, in config file, or command line argument.

Fixes - https://linear.app/commandk-dev/issue/PRD-2823/cli-has-access-token-mandatory-even-for-version-command

### What change has been made?
* Run the version subcommand bypassing CliKt execution model

### Any callouts?
**NONE**

### Testing
<!---
* Describe in brief any scenarios that have been covered as a part of the test cases and also during API testing in the dev env
-->

### Self-Checklist
- [ ] The changes are supported by test cases
- [X] The changes have been tested in a dev env

---
<!---
* Add your GitHub handle here so that you are tagged in the automated Slack message and can follow the thread
* Leave unchanged in case you do not wish to be tagged
* This workaround is needed till the request here is addressed - https://github.com/integrations/slack/issues/1620#issuecomment-1422326497
-->
Author: @rohanprabhu 

