### PR TITLE
PRD-000 Fix user-agent header in CLI client

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ $ cmdk version
 
 ```shell
 # For Linux
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.2/cmdk-cli-client-0.1.2-linux-x86_64.zip \
-    --output cmdk-cli-client-0.1.2-linux-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.3/cmdk-cli-client-0.1.3-linux-x86_64.zip \
+    --output cmdk-cli-client-0.1.3-linux-x86_64.zip
 ```
 
 ```shell
 # For MacOS
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.2/cmdk-cli-client-0.1.2-osx-x86_64.zip \
-    --output cmdk-cli-client-0.1.2-osx-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.3/cmdk-cli-client-0.1.3-osx-x86_64.zip \
+    --output cmdk-cli-client-0.1.3-osx-x86_64.zip
 ```
   
 2. After downloading the ZIP file, extract its contents using the following command (replace <file> with the actual downloaded file name), and install the binary:

--- a/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
+++ b/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
@@ -30,7 +30,7 @@ class CommandK(
 ) : CliktCommand("cmdk", autoCompleteEnvvar = CommonEnvironmentVars.CompletionScript, name = "cmdk") {
     companion object {
         const val ApplicationName = "commandk-cli"
-        const val Version = "0.1.2"
+        const val Version = "0.1.3"
     }
 
     private val loadedConfig: Map<String, String>


### PR DESCRIPTION
### Why is the change needed?
User-Agent header is not being set correctly, which is required by backend analytics to determine the calling context

### What change has been made?
User the ktor plugin for setting a user-agent

### Any callouts?
**NONE**

### Testing
* Tested headers against an echo server

### Self-Checklist
- [ ] The changes are supported by test cases
- [X] The changes have been tested in a dev env

---
<!---
* Add your GitHub handle here so that you are tagged in the automated Slack message and can follow the thread
* Leave unchanged in case you do not wish to be tagged
* This workaround is needed till the request here is addressed - https://github.com/integrations/slack/issues/1620#issuecomment-1422326497
-->
Author: @rohanprabhu 

