### PR TITLE
PRD-000 Fix/Version array lookup bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ $ cmdk version
 
 ```shell
 # For Linux
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.2/cmdk-cli-client-0.1.2-linux-x86_64.zip \
-    --output cmdk-cli-client-0.1.2-linux-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.3/cmdk-cli-client-0.1.3-linux-x86_64.zip \
+    --output cmdk-cli-client-0.1.3-linux-x86_64.zip
 ```
 
 ```shell
 # For MacOS
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.2/cmdk-cli-client-0.1.2-osx-x86_64.zip \
-    --output cmdk-cli-client-0.1.2-osx-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.3/cmdk-cli-client-0.1.3-osx-x86_64.zip \
+    --output cmdk-cli-client-0.1.3-osx-x86_64.zip
 ```
   
 2. After downloading the ZIP file, extract its contents using the following command (replace <file> with the actual downloaded file name), and install the binary:

--- a/README.md
+++ b/README.md
@@ -52,14 +52,14 @@ $ cmdk version
 
 ```shell
 # For Linux
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.3/cmdk-cli-client-0.1.3-linux-x86_64.zip \
-    --output cmdk-cli-client-0.1.3-linux-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.4/cmdk-cli-client-0.1.4-linux-x86_64.zip \
+    --output cmdk-cli-client-0.1.4-linux-x86_64.zip
 ```
 
 ```shell
 # For MacOS
-curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.3/cmdk-cli-client-0.1.3-osx-x86_64.zip \
-    --output cmdk-cli-client-0.1.3-osx-x86_64.zip
+curl -L https://github.com/commandk-dev/cli/releases/download/v0.1.4/cmdk-cli-client-0.1.4-osx-x86_64.zip \
+    --output cmdk-cli-client-0.1.4-osx-x86_64.zip
 ```
   
 2. After downloading the ZIP file, extract its contents using the following command (replace <file> with the actual downloaded file name), and install the binary:

--- a/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
+++ b/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
@@ -30,7 +30,7 @@ class CommandK(
 ) : CliktCommand("cmdk", autoCompleteEnvvar = CommonEnvironmentVars.CompletionScript, name = "cmdk") {
     companion object {
         const val ApplicationName = "commandk-cli"
-        const val Version = "0.1.2"
+        const val Version = "0.1.3"
     }
 
     private val loadedConfig: Map<String, String>

--- a/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
+++ b/src/nativeMain/kotlin/dev/commandk/cli/commandk-cli.kt
@@ -88,7 +88,7 @@ val subcommands = emptyList<CliktCommand>() +
 
 @OptIn(ExperimentalForeignApi::class)
 fun main(args: Array<String>) {
-    if (args[0] == "version") {
+    if (args.size > 1 && args[0] == "version") {
         VersionCommand(Terminal())
             .run()
     } else {


### PR DESCRIPTION
### Why is the change needed?
We lookup the first argument to bypass CliKt in case we want to display the version, but this causes issues if no argument is provided at all (required for completion script generation).

### What change has been made?
* Safe check arguments on the CLI

### Any callouts?
**None**

### Testing
* Tested for completion script generation locally

### Self-Checklist
- [ ] The changes are supported by test cases
- [X] The changes have been tested in a dev env

---
<!---
* Add your GitHub handle here so that you are tagged in the automated Slack message and can follow the thread
* Leave unchanged in case you do not wish to be tagged
* This workaround is needed till the request here is addressed - https://github.com/integrations/slack/issues/1620#issuecomment-1422326497
-->
Author: @rohanprabhu 

